### PR TITLE
let consul-template accept systemd_service as service name, like cons…

### DIFF
--- a/consul-template/service.sls
+++ b/consul-template/service.sls
@@ -2,7 +2,7 @@
 
 consul-template-init-script:
   file.managed:
-    {% if salt['test.provider']('service') == 'systemd' %}
+    {% if salt['test.provider']('service').startswith('systemd') %}
     - source: salt://consul-template/files/consul-template.service
     - name: /etc/systemd/system/consul-template.service
     - mode: 0644


### PR DESCRIPTION
debian buster returns systemd_service  vs. just systemd. 